### PR TITLE
Make AMF3 encoder reject unsupported value types with explicit error

### DIFF
--- a/internal/amf3/amf3.go
+++ b/internal/amf3/amf3.go
@@ -228,7 +228,7 @@ func (e *AMF3Encoder) encodeValue(value interface{}) error {
 	case AMF3Value:
 		return e.encodeAMF3Value(v)
 	default:
-		return e.encodeObject(v)
+		return fmt.Errorf("unsupported value type: %T", value)
 	}
 }
 


### PR DESCRIPTION
In encodeValue, replace the fallback object encoding with a typed error using fmt.Errorf("unsupported value type: %T"). This prevents silently attempting to encode arbitrary objects and surfaces clearer feedback to callers when an unsupported type is encountered.